### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -21,6 +21,10 @@
 
 name: Appknox
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Archive-program/security/code-scanning/2](https://github.com/Git-Hub-Chris/Archive-program/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the least privileges required. Based on the workflow's functionality:
1. The `contents: read` permission is needed to check out the repository code.
2. The `security-events: write` permission is required to upload SARIF files to GitHub Advanced Security (GHAS).

These permissions will be added to the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
